### PR TITLE
refactor(ccli): refactor tool to separate business logic from presentation layer

### DIFF
--- a/tools/ccli/cmd/compile.go
+++ b/tools/ccli/cmd/compile.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"strings"
 
+	"github.com/STommydx/cp-templates/tools/ccli/output"
 	"github.com/STommydx/cp-templates/tools/ccli/submission"
 	"github.com/spf13/cobra"
 )
@@ -22,16 +22,17 @@ var compileCmd = &cobra.Command{
 This command compiles source files to binary. This also packs source files into a single file for online judge submissions.`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		out := output.NewTerminalOutputter(os.Stderr)
 		sourceFileName := path.Base(args[0])
 		if packSubmission {
 			if submissionPath == "" {
 				submissionPath = path.Join("./submissions/", sourceFileName)
 			}
-			if err := submission.Pack(submission.PackSettings{
+			if err := submission.PackWithOutput(submission.PackSettings{
 				SourceFiles: args,
 				OutputPath:  submissionPath,
-			}); err != nil {
-				fmt.Fprintln(os.Stderr, err)
+			}, out); err != nil {
+				out.Error(err.Error())
 				os.Exit(1)
 			}
 		}
@@ -39,12 +40,12 @@ This command compiles source files to binary. This also packs source files into 
 			outputFileName := strings.ReplaceAll(sourceFileName, ".cpp", ".out")
 			outputPath = path.Join("./build/", outputFileName)
 		}
-		if err := submission.Compile(submission.CompileSettings{
+		if err := submission.CompileWithOutput(submission.CompileSettings{
 			SourceFiles:      []string{submissionPath},
 			OutputPath:       outputPath,
 			CompilationFlags: strings.Split(compilationFlags, " "),
-		}); err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		}, out); err != nil {
+			out.Error(err.Error())
 			os.Exit(1)
 		}
 	},

--- a/tools/ccli/cmd/init.go
+++ b/tools/ccli/cmd/init.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
+	"github.com/STommydx/cp-templates/tools/ccli/output"
 	"github.com/STommydx/cp-templates/tools/ccli/repoinit"
 	"github.com/spf13/cobra"
 )
@@ -18,17 +18,18 @@ var initCmd = &cobra.Command{
 	Long:  `Initialize a new repository for programming contests. Creates configurable number of starting main program files and download templates to template folder.`,
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		out := output.NewTerminalOutputter(os.Stderr)
 		directory := "./"
 		if len(args) > 0 {
 			directory = args[0]
 		}
-		if err := repoinit.Run(repoinit.Settings{
+		if err := repoinit.RunWithOutput(repoinit.Settings{
 			Directory:             directory,
 			NumberOfMainPrograms:  mainProgramCount,
 			TemplateRepositoryUrl: templateRepository,
 			IncludeTestlib:        includeTestlib,
-		}); err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		}, out); err != nil {
+			out.Error(err.Error())
 			os.Exit(1)
 		}
 	},

--- a/tools/ccli/cmd/pack.go
+++ b/tools/ccli/cmd/pack.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path"
 
+	"github.com/STommydx/cp-templates/tools/ccli/output"
 	"github.com/STommydx/cp-templates/tools/ccli/submission"
 	"github.com/spf13/cobra"
 )
@@ -17,15 +17,16 @@ var packCmd = &cobra.Command{
 	Long:  `Pack source files into a single file for online judge submissions.`,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		out := output.NewTerminalOutputter(os.Stderr)
 		sourceFileName := path.Base(args[0])
 		if outputPath == "" {
 			outputPath = path.Join("./submissions/", sourceFileName)
 		}
-		if err := submission.Pack(submission.PackSettings{
+		if err := submission.PackWithOutput(submission.PackSettings{
 			SourceFiles: args,
 			OutputPath:  outputPath,
-		}); err != nil {
-			fmt.Fprintln(os.Stderr, err)
+		}, out); err != nil {
+			out.Error(err.Error())
 			os.Exit(1)
 		}
 	},

--- a/tools/ccli/output/output.go
+++ b/tools/ccli/output/output.go
@@ -1,0 +1,50 @@
+package output
+
+import (
+	"io"
+)
+
+// Outputter defines the interface for output operations
+type Outputter interface {
+	// Info prints informational messages
+	Info(message string)
+
+	// Infof prints formatted informational messages
+	Infof(format string, args ...interface{})
+
+	// Warn prints warning messages
+	Warn(message string)
+
+	// Warnf prints formatted warning messages
+	Warnf(format string, args ...interface{})
+
+	// Error prints error messages
+	Error(message string)
+
+	// Errorf prints formatted error messages
+	Errorf(format string, args ...interface{})
+
+	// Success prints success messages
+	Success(message string)
+
+	// Successf prints formatted success messages
+	Successf(format string, args ...interface{})
+
+	// WithSpinner creates a new spinner with the given message
+	WithSpinner(message string) Spinner
+
+	// Writer returns the underlying writer for direct output
+	Writer() io.Writer
+}
+
+// Spinner defines the interface for spinner operations
+type Spinner interface {
+	// Start starts the spinner
+	Start() error
+
+	// Stop stops the spinner
+	Stop() error
+
+	// StopFail stops the spinner with a failure indication
+	StopFail() error
+}

--- a/tools/ccli/output/output_test.go
+++ b/tools/ccli/output/output_test.go
@@ -1,0 +1,109 @@
+package output
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTerminalOutputter(t *testing.T) {
+	out := NewTerminalOutputter(&strings.Builder{})
+
+	// Test basic output methods
+	out.Info("Info message")
+	out.Warn("Warning message")
+	out.Error("Error message")
+	out.Success("Success message")
+
+	// These methods don't write to the builder directly, so we can't easily test them
+	// but we can at least verify they don't panic
+	out.Infof("Info %s", "formatted")
+	out.Warnf("Warning %s", "formatted")
+	out.Errorf("Error %s", "formatted")
+	out.Successf("Success %s", "formatted")
+
+	// Test spinner creation
+	spinner := out.WithSpinner("Test message")
+	if spinner == nil {
+		t.Error("WithSpinner returned nil")
+	}
+
+	// Test that spinner methods don't panic
+	spinner.Start()
+	spinner.Stop()
+	spinner.StopFail()
+}
+
+func TestTestOutputter(t *testing.T) {
+	out := NewTestOutputter()
+
+	// Test basic output methods
+	out.Info("Info message")
+	out.Warn("Warning message")
+	out.Error("Error message")
+	out.Success("Success message")
+
+	// Check output
+	output := out.Output()
+	if !strings.Contains(output, "INFO: Info message") {
+		t.Error("Info message not found in output")
+	}
+	if !strings.Contains(output, "WARN: Warning message") {
+		t.Error("Warning message not found in output")
+	}
+	if !strings.Contains(output, "ERROR: Error message") {
+		t.Error("Error message not found in output")
+	}
+	if !strings.Contains(output, "SUCCESS: Success message") {
+		t.Error("Success message not found in output")
+	}
+
+	// Clear output
+	out.Clear()
+	if out.Output() != "" {
+		t.Error("Output was not cleared")
+	}
+
+	// Test formatted output methods
+	out.Infof("Info %s", "formatted")
+	out.Warnf("Warning %s", "formatted")
+	out.Errorf("Error %s", "formatted")
+	out.Successf("Success %s", "formatted")
+
+	// Check formatted output
+	output = out.Output()
+	if !strings.Contains(output, "INFO: Info formatted") {
+		t.Error("Formatted info message not found in output")
+	}
+	if !strings.Contains(output, "WARN: Warning formatted") {
+		t.Error("Formatted warning message not found in output")
+	}
+	if !strings.Contains(output, "ERROR: Error formatted") {
+		t.Error("Formatted error message not found in output")
+	}
+	if !strings.Contains(output, "SUCCESS: Success formatted") {
+		t.Error("Formatted success message not found in output")
+	}
+
+	// Test spinner
+	spinner := out.WithSpinner("Test message")
+	if spinner == nil {
+		t.Error("WithSpinner returned nil")
+	}
+
+	// Test spinner methods
+	spinner.Start()
+	spinner.Stop()
+	spinner.StopFail()
+
+	// Check spinner output
+	output = out.Output()
+	if !strings.Contains(output, "SPINNER START: Test message") {
+		t.Error("Spinner start message not found in output")
+	}
+	if !strings.Contains(output, "SPINNER STOP: Test message") {
+		t.Error("Spinner stop message not found in output")
+	}
+	if !strings.Contains(output, "SPINNER STOP FAIL: Test message") {
+		t.Error("Spinner stop fail message not found in output")
+	}
+}

--- a/tools/ccli/output/terminal.go
+++ b/tools/ccli/output/terminal.go
@@ -1,0 +1,144 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
+	"github.com/theckman/yacspin"
+)
+
+// TerminalOutputter implements Outputter for terminal output
+type TerminalOutputter struct {
+	writer io.Writer
+}
+
+// NewTerminalOutputter creates a new TerminalOutputter
+func NewTerminalOutputter(writer io.Writer) *TerminalOutputter {
+	return &TerminalOutputter{
+		writer: writer,
+	}
+}
+
+// Info prints informational messages
+func (t *TerminalOutputter) Info(message string) {
+	fmt.Fprintln(t.writer, message)
+}
+
+// Infof prints formatted informational messages
+func (t *TerminalOutputter) Infof(format string, args ...interface{}) {
+	fmt.Fprintf(t.writer, format+"\n", args...)
+}
+
+// Warn prints warning messages
+func (t *TerminalOutputter) Warn(message string) {
+	color.New(color.FgYellow).Fprintln(t.writer, message)
+}
+
+// Warnf prints formatted warning messages
+func (t *TerminalOutputter) Warnf(format string, args ...interface{}) {
+	color.New(color.FgYellow).Fprintf(t.writer, format+"\n", args...)
+}
+
+// Error prints error messages
+func (t *TerminalOutputter) Error(message string) {
+	color.New(color.FgRed).Fprintln(t.writer, message)
+}
+
+// Errorf prints formatted error messages
+func (t *TerminalOutputter) Errorf(format string, args ...interface{}) {
+	color.New(color.FgRed).Fprintf(t.writer, format+"\n", args...)
+}
+
+// Success prints success messages
+func (t *TerminalOutputter) Success(message string) {
+	color.New(color.FgGreen).Fprintln(t.writer, message)
+}
+
+// Successf prints formatted success messages
+func (t *TerminalOutputter) Successf(format string, args ...interface{}) {
+	color.New(color.FgGreen).Fprintf(t.writer, format+"\n", args...)
+}
+
+// WithSpinner creates a new spinner with the given message
+func (t *TerminalOutputter) WithSpinner(message string) Spinner {
+	if !isatty.IsTerminal(os.Stderr.Fd()) {
+		return &noopSpinner{}
+	}
+
+	spinnerConfig := yacspin.Config{
+		Frequency:         100 * time.Millisecond,
+		CharSet:           yacspin.CharSets[11],
+		Suffix:            " ",
+		Message:           message,
+		SuffixAutoColon:   true,
+		ColorAll:          true,
+		Colors:            []string{"fgYellow"},
+		StopCharacter:     "✓",
+		StopColors:        []string{"fgGreen"},
+		StopMessage:       message,
+		StopFailCharacter: "✗",
+		StopFailColors:    []string{"fgRed"},
+		StopFailMessage:   message,
+		Writer:            os.Stderr,
+	}
+
+	spinner, err := yacspin.New(spinnerConfig)
+	if err != nil {
+		// Fallback to noop spinner if we can't create a real one
+		return &noopSpinner{}
+	}
+
+	return &terminalSpinner{spinner: spinner}
+}
+
+// Writer returns the underlying writer for direct output
+func (t *TerminalOutputter) Writer() io.Writer {
+	return t.writer
+}
+
+// terminalSpinner wraps yacspin.Spinner
+type terminalSpinner struct {
+	spinner *yacspin.Spinner
+}
+
+// Start starts the spinner
+func (t *terminalSpinner) Start() error {
+	return t.spinner.Start()
+}
+
+// Stop stops the spinner
+func (t *terminalSpinner) Stop() error {
+	return t.spinner.Stop()
+}
+
+// StopFail stops the spinner with a failure indication
+func (t *terminalSpinner) StopFail() error {
+	return t.spinner.StopFail()
+}
+
+// noopSpinner is a no-op implementation of Spinner for non-terminal environments
+type noopSpinner struct{}
+
+// Start is a no-op
+func (n *noopSpinner) Start() error {
+	return nil
+}
+
+// Stop is a no-op
+func (n *noopSpinner) Stop() error {
+	return nil
+}
+
+// StopFail is a no-op
+func (n *noopSpinner) StopFail() error {
+	return nil
+}
+
+// DefaultTerminalOutputter returns a TerminalOutputter that writes to stderr
+func DefaultTerminalOutputter() *TerminalOutputter {
+	return NewTerminalOutputter(os.Stderr)
+}

--- a/tools/ccli/output/test.go
+++ b/tools/ccli/output/test.go
@@ -1,0 +1,147 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+// TestOutputter implements Outputter for testing purposes
+type TestOutputter struct {
+	mu     sync.Mutex
+	output strings.Builder
+}
+
+// NewTestOutputter creates a new TestOutputter
+func NewTestOutputter() *TestOutputter {
+	return &TestOutputter{}
+}
+
+// Info prints informational messages
+func (t *TestOutputter) Info(message string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.output.WriteString("INFO: " + message + "\n")
+}
+
+// Infof prints formatted informational messages
+func (t *TestOutputter) Infof(format string, args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.output.WriteString("INFO: " + fmt.Sprintf(format, args...) + "\n")
+}
+
+// Warn prints warning messages
+func (t *TestOutputter) Warn(message string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.output.WriteString("WARN: " + message + "\n")
+}
+
+// Warnf prints formatted warning messages
+func (t *TestOutputter) Warnf(format string, args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.output.WriteString("WARN: " + fmt.Sprintf(format, args...) + "\n")
+}
+
+// Error prints error messages
+func (t *TestOutputter) Error(message string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.output.WriteString("ERROR: " + message + "\n")
+}
+
+// Errorf prints formatted error messages
+func (t *TestOutputter) Errorf(format string, args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.output.WriteString("ERROR: " + fmt.Sprintf(format, args...) + "\n")
+}
+
+// Success prints success messages
+func (t *TestOutputter) Success(message string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.output.WriteString("SUCCESS: " + message + "\n")
+}
+
+// Successf prints formatted success messages
+func (t *TestOutputter) Successf(format string, args ...interface{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.output.WriteString("SUCCESS: " + fmt.Sprintf(format, args...) + "\n")
+}
+
+// WithSpinner creates a new test spinner
+func (t *TestOutputter) WithSpinner(message string) Spinner {
+	return &testSpinner{message: message, outputter: t}
+}
+
+// Writer returns the underlying writer for direct output
+func (t *TestOutputter) Writer() io.Writer {
+	return &testWriter{outputter: t}
+}
+
+// Output returns the accumulated output
+func (t *TestOutputter) Output() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.output.String()
+}
+
+// Clear clears the accumulated output
+func (t *TestOutputter) Clear() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.output.Reset()
+}
+
+// testSpinner is a test implementation of Spinner
+type testSpinner struct {
+	message   string
+	outputter *TestOutputter
+	isStarted bool
+	isStopped bool
+	isFailed  bool
+}
+
+// Start starts the spinner
+func (t *testSpinner) Start() error {
+	t.isStarted = true
+	t.outputter.mu.Lock()
+	defer t.outputter.mu.Unlock()
+	t.outputter.output.WriteString("SPINNER START: " + t.message + "\n")
+	return nil
+}
+
+// Stop stops the spinner
+func (t *testSpinner) Stop() error {
+	t.isStopped = true
+	t.outputter.mu.Lock()
+	defer t.outputter.mu.Unlock()
+	t.outputter.output.WriteString("SPINNER STOP: " + t.message + "\n")
+	return nil
+}
+
+// StopFail stops the spinner with a failure indication
+func (t *testSpinner) StopFail() error {
+	t.isFailed = true
+	t.outputter.mu.Lock()
+	defer t.outputter.mu.Unlock()
+	t.outputter.output.WriteString("SPINNER STOP FAIL: " + t.message + "\n")
+	return nil
+}
+
+// testWriter is a test implementation of io.Writer
+type testWriter struct {
+	outputter *TestOutputter
+}
+
+// Write writes to the test output
+func (t *testWriter) Write(p []byte) (n int, err error) {
+	t.outputter.mu.Lock()
+	defer t.outputter.mu.Unlock()
+	return t.outputter.output.Write(p)
+}

--- a/tools/ccli/repoinit/repoinit.go
+++ b/tools/ccli/repoinit/repoinit.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/STommydx/cp-templates/tools/ccli/spinner"
+	"github.com/STommydx/cp-templates/tools/ccli/output"
 	"github.com/go-git/go-git/v5"
 )
 
@@ -25,190 +25,277 @@ type Settings struct {
 //go:embed templates/*
 var templatesFS embed.FS
 
-func Run(settings Settings) error {
-	if err := spinner.Run("Create repository directory", func() error {
-		if _, err := os.Stat(settings.Directory); os.IsNotExist(err) {
-			err := os.Mkdir(settings.Directory, os.ModePerm)
-			if err != nil {
-				return fmt.Errorf("failed to create directory: %w", err)
-			}
-		}
-		return nil
-	}); err != nil {
+// RunWithOutput initializes a new repository with the given outputter for messaging
+func RunWithOutput(settings Settings, out output.Outputter) error {
+	spinner := out.WithSpinner("Create repository directory")
+	if err := spinner.Start(); err != nil {
 		return err
 	}
-	if err := spinner.Run("Create main program files", func() error {
-		copyFile := func(source, destination string) error {
-			templateFile, err := templatesFS.Open(path.Join("templates", source))
-			if err != nil {
-				return fmt.Errorf("failed to open template file: %w", err)
-			}
-			defer templateFile.Close()
-			file, err := os.Create(filepath.Join(settings.Directory, destination))
-			if err != nil {
-				return fmt.Errorf("failed to create file: %w", err)
-			}
-			defer file.Close()
-			if _, err := io.Copy(file, templateFile); err != nil {
-				return fmt.Errorf("failed to copy template file: %w", err)
-			}
-			return nil
+
+	if _, err := os.Stat(settings.Directory); os.IsNotExist(err) {
+		err := os.Mkdir(settings.Directory, os.ModePerm)
+		if err != nil {
+			spinner.StopFail()
+			return fmt.Errorf("failed to create directory: %w", err)
 		}
-		if !settings.IncludeTestlib {
-			for i := 1; i <= settings.NumberOfMainPrograms; i++ {
-				if err := copyFile("main.cpp", fmt.Sprintf("%c.cpp", rune(64+i))); err != nil {
-					return err
-				}
-			}
-		} else {
-			if err := copyFile("main.cpp", "solution.cpp"); err != nil {
-				return err
-			}
-			if err := copyFile("gen.cpp", "gen.cpp"); err != nil {
-				return err
-			}
-			if err := copyFile("checker.cpp", "checker.cpp"); err != nil {
-				return err
-			}
-			if err := copyFile("val.cpp", "val.cpp"); err != nil {
-				return err
-			}
-			if err := copyFile("interactor.cpp", "interactor.cpp"); err != nil {
-				return err
-			}
-		}
-		return nil
-	}); err != nil {
+	}
+
+	if err := spinner.Stop(); err != nil {
 		return err
 	}
+
+	spinner = out.WithSpinner("Create main program files")
+	if err := spinner.Start(); err != nil {
+		return err
+	}
+
+	copyFile := func(source, destination string) error {
+		templateFile, err := templatesFS.Open(path.Join("templates", source))
+		if err != nil {
+			return fmt.Errorf("failed to open template file: %w", err)
+		}
+		defer templateFile.Close()
+
+		file, err := os.Create(filepath.Join(settings.Directory, destination))
+		if err != nil {
+			return fmt.Errorf("failed to create file: %w", err)
+		}
+		defer file.Close()
+
+		if _, err := io.Copy(file, templateFile); err != nil {
+			return fmt.Errorf("failed to copy template file: %w", err)
+		}
+		return nil
+	}
+
+	if !settings.IncludeTestlib {
+		for i := 1; i <= settings.NumberOfMainPrograms; i++ {
+			if err := copyFile("main.cpp", fmt.Sprintf("%c.cpp", rune(64+i))); err != nil {
+				spinner.StopFail()
+				return err
+			}
+		}
+	} else {
+		if err := copyFile("main.cpp", "solution.cpp"); err != nil {
+			spinner.StopFail()
+			return err
+		}
+		if err := copyFile("gen.cpp", "gen.cpp"); err != nil {
+			spinner.StopFail()
+			return err
+		}
+		if err := copyFile("checker.cpp", "checker.cpp"); err != nil {
+			spinner.StopFail()
+			return err
+		}
+		if err := copyFile("val.cpp", "val.cpp"); err != nil {
+			spinner.StopFail()
+			return err
+		}
+		if err := copyFile("interactor.cpp", "interactor.cpp"); err != nil {
+			spinner.StopFail()
+			return err
+		}
+	}
+
+	if err := spinner.Stop(); err != nil {
+		return err
+	}
+
 	templateFiles := []string{
 		".gitignore",
 		".clang-format",
 	}
-	if err := spinner.Run("Create template files", func() error {
-		for _, templateFilename := range templateFiles {
-			templateFile, err := templatesFS.Open(path.Join("templates", templateFilename))
-			if err != nil {
-				return fmt.Errorf("failed to open template file %s: %w", templateFilename, err)
-			}
-			defer templateFile.Close()
-			file, err := os.Create(path.Join(settings.Directory, templateFilename))
-			if err != nil {
-				return fmt.Errorf("failed to create file: %w", err)
-			}
-			defer file.Close()
-			if _, err := io.Copy(file, templateFile); err != nil {
-				return fmt.Errorf("failed to copy template file: %w", err)
-			}
+
+	spinner = out.WithSpinner("Create template files")
+	if err := spinner.Start(); err != nil {
+		return err
+	}
+
+	for _, templateFilename := range templateFiles {
+		templateFile, err := templatesFS.Open(path.Join("templates", templateFilename))
+		if err != nil {
+			spinner.StopFail()
+			return fmt.Errorf("failed to open template file %s: %w", templateFilename, err)
 		}
-		cmakeConfig := struct {
-			ProjectName string
-			SourceFiles []struct {
+		defer templateFile.Close()
+
+		file, err := os.Create(path.Join(settings.Directory, templateFilename))
+		if err != nil {
+			spinner.StopFail()
+			return fmt.Errorf("failed to create file: %w", err)
+		}
+		defer file.Close()
+
+		if _, err := io.Copy(file, templateFile); err != nil {
+			spinner.StopFail()
+			return fmt.Errorf("failed to copy template file: %w", err)
+		}
+	}
+
+	cmakeConfig := struct {
+		ProjectName string
+		SourceFiles []struct {
+			Input  string
+			Output string
+		}
+	}{
+		ProjectName: path.Base(settings.Directory),
+	}
+
+	files, err := os.ReadDir(settings.Directory)
+	if err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	for _, file := range files {
+		if filepath.Ext(file.Name()) == ".cpp" {
+			cmakeConfig.SourceFiles = append(cmakeConfig.SourceFiles, struct {
 				Input  string
 				Output string
-			}
-		}{
-			ProjectName: path.Base(settings.Directory),
+			}{
+				Input:  file.Name(),
+				Output: strings.ReplaceAll(file.Name(), ".cpp", ".out"),
+			})
 		}
-		files, err := os.ReadDir(settings.Directory)
-		if err != nil {
-			return fmt.Errorf("failed to read directory: %w", err)
-		}
-		for _, file := range files {
-			if filepath.Ext(file.Name()) == ".cpp" {
-				cmakeConfig.SourceFiles = append(cmakeConfig.SourceFiles, struct {
-					Input  string
-					Output string
-				}{
-					Input:  file.Name(),
-					Output: strings.ReplaceAll(file.Name(), ".cpp", ".out"),
-				})
-			}
-		}
-		cmakeListFile, err := os.Create(path.Join(settings.Directory, "CMakeLists.txt"))
-		if err != nil {
-			return fmt.Errorf("failed to create CMakeLists.txt file: %w", err)
-		}
-		defer cmakeListFile.Close()
-		cmakeListTemplate := template.Must(template.ParseFS(templatesFS, "templates/CMakeLists.txt.tmpl"))
-		if err := cmakeListTemplate.Execute(cmakeListFile, cmakeConfig); err != nil {
-			return fmt.Errorf("failed to execute CMakeLists.txt template: %w", err)
-		}
-		return nil
-	}); err != nil {
+	}
+
+	cmakeListFile, err := os.Create(path.Join(settings.Directory, "CMakeLists.txt"))
+	if err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to create CMakeLists.txt file: %w", err)
+	}
+	defer cmakeListFile.Close()
+
+	cmakeListTemplate := template.Must(template.ParseFS(templatesFS, "templates/CMakeLists.txt.tmpl"))
+	if err := cmakeListTemplate.Execute(cmakeListFile, cmakeConfig); err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to execute CMakeLists.txt template: %w", err)
+	}
+
+	if err := spinner.Stop(); err != nil {
 		return err
 	}
-	if err := spinner.Run("Initialize git repository", func() error {
-		repo, err := git.PlainInit(settings.Directory, false)
-		if err != nil {
-			return fmt.Errorf("failed to initialize git repository: %w", err)
-		}
-		worktree, err := repo.Worktree()
-		if err != nil {
-			return fmt.Errorf("failed to get worktree of git repository: %w", err)
-		}
-		if _, err := worktree.Add("."); err != nil {
-			return fmt.Errorf("failed to add files to git repository: %w", err)
-		}
-		if _, err := worktree.Commit("feat: initial repository with main templates", &git.CommitOptions{}); err != nil {
-			return fmt.Errorf("failed to commit main files to git repository: %w", err)
-		}
-		return nil
-	}); err != nil {
+
+	spinner = out.WithSpinner("Initialize git repository")
+	if err := spinner.Start(); err != nil {
 		return err
 	}
-	if err := spinner.Run("Download templates", func() error {
-		addSubModuleCmd := exec.Command("git", "submodule", "add", settings.TemplateRepositoryUrl, "templates")
+
+	repo, err := git.PlainInit(settings.Directory, false)
+	if err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to initialize git repository: %w", err)
+	}
+
+	worktree, err := repo.Worktree()
+	if err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to get worktree of git repository: %w", err)
+	}
+
+	if _, err := worktree.Add("."); err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to add files to git repository: %w", err)
+	}
+
+	if _, err := worktree.Commit("feat: initial repository with main templates", &git.CommitOptions{}); err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to commit main files to git repository: %w", err)
+	}
+
+	if err := spinner.Stop(); err != nil {
+		return err
+	}
+
+	spinner = out.WithSpinner("Download templates")
+	if err := spinner.Start(); err != nil {
+		return err
+	}
+
+	addSubModuleCmd := exec.Command("git", "submodule", "add", settings.TemplateRepositoryUrl, "templates")
+	addSubModuleCmd.Dir = settings.Directory
+	if err := addSubModuleCmd.Run(); err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to add submodule to git repository: %w", err)
+	}
+
+	repo, err = git.PlainOpen(settings.Directory)
+	if err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to open git repository: %w", err)
+	}
+
+	worktree, err = repo.Worktree()
+	if err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to get worktree of git repository: %w", err)
+	}
+
+	if _, err := worktree.Add("."); err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to add files to git repository: %w", err)
+	}
+
+	if _, err := worktree.Commit("feat: add templates submodule", &git.CommitOptions{}); err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to commit template files to git repository: %w", err)
+	}
+
+	if err := spinner.Stop(); err != nil {
+		return err
+	}
+
+	if settings.IncludeTestlib {
+		spinner = out.WithSpinner("Download testlib")
+		if err := spinner.Start(); err != nil {
+			return err
+		}
+
+		addSubModuleCmd := exec.Command("git", "submodule", "add", "git@github.com:MikeMirzayanov/testlib.git", "testlib")
 		addSubModuleCmd.Dir = settings.Directory
 		if err := addSubModuleCmd.Run(); err != nil {
+			spinner.StopFail()
 			return fmt.Errorf("failed to add submodule to git repository: %w", err)
 		}
+
+		if err := os.Symlink(filepath.Join("testlib", "testlib.h"), filepath.Join(settings.Directory, "testlib.h")); err != nil {
+			spinner.StopFail()
+			return fmt.Errorf("failed to create symlink to testlib.h: %w", err)
+		}
+
 		repo, err := git.PlainOpen(settings.Directory)
 		if err != nil {
+			spinner.StopFail()
 			return fmt.Errorf("failed to open git repository: %w", err)
 		}
+
 		worktree, err := repo.Worktree()
 		if err != nil {
+			spinner.StopFail()
 			return fmt.Errorf("failed to get worktree of git repository: %w", err)
 		}
+
 		if _, err := worktree.Add("."); err != nil {
+			spinner.StopFail()
 			return fmt.Errorf("failed to add files to git repository: %w", err)
 		}
-		if _, err := worktree.Commit("feat: add templates submodule", &git.CommitOptions{}); err != nil {
+
+		if _, err := worktree.Commit("feat: add testlib submodule", &git.CommitOptions{}); err != nil {
+			spinner.StopFail()
 			return fmt.Errorf("failed to commit template files to git repository: %w", err)
 		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	if settings.IncludeTestlib {
-		if err := spinner.Run("Download testlib", func() error {
-			addSubModuleCmd := exec.Command("git", "submodule", "add", "git@github.com:MikeMirzayanov/testlib.git", "testlib")
-			addSubModuleCmd.Dir = settings.Directory
-			if err := addSubModuleCmd.Run(); err != nil {
-				return fmt.Errorf("failed to add submodule to git repository: %w", err)
-			}
-			if err := os.Symlink(filepath.Join("testlib", "testlib.h"), filepath.Join(settings.Directory, "testlib.h")); err != nil {
-				return fmt.Errorf("failed to create symlink to testlib.h: %w", err)
-			}
-			repo, err := git.PlainOpen(settings.Directory)
-			if err != nil {
-				return fmt.Errorf("failed to open git repository: %w", err)
-			}
-			worktree, err := repo.Worktree()
-			if err != nil {
-				return fmt.Errorf("failed to get worktree of git repository: %w", err)
-			}
-			if _, err := worktree.Add("."); err != nil {
-				return fmt.Errorf("failed to add files to git repository: %w", err)
-			}
-			if _, err := worktree.Commit("feat: add testlib submodule", &git.CommitOptions{}); err != nil {
-				return fmt.Errorf("failed to commit template files to git repository: %w", err)
-			}
-			return nil
-		}); err != nil {
+
+		if err := spinner.Stop(); err != nil {
 			return err
 		}
 	}
+
 	return nil
+}
+
+// Run initializes a new repository using the default terminal outputter (backward compatibility)
+func Run(settings Settings) error {
+	return RunWithOutput(settings, output.DefaultTerminalOutputter())
 }

--- a/tools/ccli/repoinit/repoinit_test.go
+++ b/tools/ccli/repoinit/repoinit_test.go
@@ -1,0 +1,63 @@
+package repoinit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/STommydx/cp-templates/tools/ccli/output"
+)
+
+func TestRunWithOutput(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "ccli_repoinit_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Test initializing a repository
+	testDir := filepath.Join(tempDir, "test_repo")
+	settings := Settings{
+		Directory:             testDir,
+		NumberOfMainPrograms:  3,
+		TemplateRepositoryUrl: "https://github.com/STommydx/cp-templates.git",
+		IncludeTestlib:        false,
+	}
+
+	out := output.NewTestOutputter()
+	err = RunWithOutput(settings, out)
+	if err != nil {
+		// We expect this to fail because we're not actually connecting to GitHub
+		// But we can still check that the basic directory structure was created
+		t.Logf("RunWithOutput failed (expected): %v", err)
+	}
+
+	// Check that the directory was created
+	if _, err := os.Stat(testDir); os.IsNotExist(err) {
+		t.Error("Repository directory was not created")
+	}
+
+	// Check that some basic files were created
+	expectedFiles := []string{
+		"A.cpp",
+		"B.cpp",
+		"C.cpp",
+		".gitignore",
+		".clang-format",
+		"CMakeLists.txt",
+	}
+
+	for _, file := range expectedFiles {
+		filePath := filepath.Join(testDir, file)
+		if _, err := os.Stat(filePath); os.IsNotExist(err) {
+			t.Errorf("Expected file %s was not created", file)
+		}
+	}
+
+	// Check that the output contains expected messages
+	outputStr := out.Output()
+	if outputStr == "" {
+		t.Error("No output was generated")
+	}
+}

--- a/tools/ccli/submission/compile.go
+++ b/tools/ccli/submission/compile.go
@@ -8,8 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/STommydx/cp-templates/tools/ccli/spinner"
-	"github.com/fatih/color"
+	"github.com/STommydx/cp-templates/tools/ccli/output"
 	"github.com/mattn/go-isatty"
 )
 
@@ -19,42 +18,68 @@ type CompileSettings struct {
 	CompilationFlags []string
 }
 
-func Compile(settings CompileSettings) error {
-	if err := spinner.Run("Create output directory", func() error {
-		outputDir := filepath.Dir(settings.OutputPath)
-		if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-			err := os.Mkdir(outputDir, os.ModePerm)
-			if err != nil {
-				return fmt.Errorf("failed to create directory: %w", err)
-			}
-		}
-		return nil
-	}); err != nil {
+// CompileWithOutput compiles source files with the given outputter for messaging
+func CompileWithOutput(settings CompileSettings, out output.Outputter) error {
+	spinner := out.WithSpinner("Create output directory")
+	if err := spinner.Start(); err != nil {
 		return err
 	}
+
+	outputDir := filepath.Dir(settings.OutputPath)
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		err := os.Mkdir(outputDir, os.ModePerm)
+		if err != nil {
+			spinner.StopFail()
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+	}
+
+	if err := spinner.Stop(); err != nil {
+		return err
+	}
+
 	isUpdateToDate, err := isUpToDate(settings.OutputPath, settings.SourceFiles)
 	if err != nil {
 		return err
 	}
+
 	if isUpdateToDate {
-		if isatty.IsTerminal(os.Stderr.Fd()) {
-			color.New(color.FgYellow).Fprintln(os.Stderr, "⚠ Executable is up-to-date, skipping compilation")
-		}
+		out.Warn("⚠ Executable is up-to-date, skipping compilation")
 		return nil
 	}
+
+	spinner = out.WithSpinner("Compile source files")
+	if err := spinner.Start(); err != nil {
+		return err
+	}
+
+	compileArgs := append(settings.SourceFiles, "-o", settings.OutputPath)
+	if isatty.IsTerminal(os.Stderr.Fd()) {
+		compileArgs = append(compileArgs, "-fdiagnostics-color=always")
+	}
+	compileArgs = append(compileArgs, settings.CompilationFlags...)
+
+	compileCommand := exec.Command("g++", compileArgs...)
 	var stderrBuf bytes.Buffer
-	defer io.Copy(os.Stderr, &stderrBuf)
-	return spinner.Run("Compile source files", func() error {
-		compileArgs := append(settings.SourceFiles, "-o", settings.OutputPath)
-		if isatty.IsTerminal(os.Stderr.Fd()) {
-			compileArgs = append(compileArgs, "-fdiagnostics-color=always")
-		}
-		compileArgs = append(compileArgs, settings.CompilationFlags...)
-		compileCommand := exec.Command("g++", compileArgs...)
-		compileCommand.Stderr = &stderrBuf
-		if err := compileCommand.Run(); err != nil {
-			return fmt.Errorf("failed to start compile command: %w", err)
-		}
-		return nil
-	})
+	compileCommand.Stderr = &stderrBuf
+
+	if err := compileCommand.Run(); err != nil {
+		spinner.StopFail()
+		// Copy stderr to output
+		io.Copy(out.Writer(), &stderrBuf)
+		return fmt.Errorf("failed to start compile command: %w", err)
+	}
+
+	if err := spinner.Stop(); err != nil {
+		return err
+	}
+
+	// Copy stderr to output
+	io.Copy(out.Writer(), &stderrBuf)
+	return nil
+}
+
+// Compile compiles source files using the default terminal outputter (backward compatibility)
+func Compile(settings CompileSettings) error {
+	return CompileWithOutput(settings, output.DefaultTerminalOutputter())
 }

--- a/tools/ccli/submission/pack.go
+++ b/tools/ccli/submission/pack.go
@@ -7,10 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/fatih/color"
-	"github.com/mattn/go-isatty"
-
-	"github.com/STommydx/cp-templates/tools/ccli/spinner"
+	"github.com/STommydx/cp-templates/tools/ccli/output"
 )
 
 type PackSettings struct {
@@ -18,79 +15,77 @@ type PackSettings struct {
 	OutputPath  string
 }
 
-func Pack(settings PackSettings) error {
-	if err := spinner.Run("Create submission directory", func() error {
-		outputDir := filepath.Dir(settings.OutputPath)
-		if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-			err := os.Mkdir(outputDir, os.ModePerm)
-			if err != nil {
-				return fmt.Errorf("failed to create directory: %w", err)
-			}
-		}
-		return nil
-	}); err != nil {
+// PackWithOutput packs source files with the given outputter for messaging
+func PackWithOutput(settings PackSettings, out output.Outputter) error {
+	spinner := out.WithSpinner("Create submission directory")
+	if err := spinner.Start(); err != nil {
 		return err
 	}
+
+	outputDir := filepath.Dir(settings.OutputPath)
+	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+		err := os.Mkdir(outputDir, os.ModePerm)
+		if err != nil {
+			spinner.StopFail()
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+	}
+
+	if err := spinner.Stop(); err != nil {
+		return err
+	}
+
 	isUpdateToDate, err := isUpToDate(settings.OutputPath, settings.SourceFiles)
 	if err != nil {
 		return err
 	}
+
 	if isUpdateToDate {
-		if isatty.IsTerminal(os.Stderr.Fd()) {
-			color.New(color.FgYellow).Fprintln(os.Stderr, "⚠ Submission file is up-to-date, skipping packing")
-		}
+		out.Warn("⚠ Submission file is up-to-date, skipping packing")
 		return nil
 	}
-	if err := spinner.Run("Pack source files", func() error {
-		outputFile, err := os.Create(settings.OutputPath)
-		if err != nil {
-			return fmt.Errorf("failed to create output file: %w", err)
-		}
-		defer outputFile.Close()
-		writer := bufio.NewWriter(outputFile)
-		defer writer.Flush()
-		writeCount := make(map[string]int)
-		for _, sourceFilePath := range settings.SourceFiles {
-			var parseAndWriteSourceFile func(sourceFilePath string) error
-			parseAndWriteSourceFile = func(sourceFilePath string) error {
-				if _, ok := writeCount[sourceFilePath]; ok {
-					return nil
-				}
-				writeCount[sourceFilePath] = 1
-				sourceFile, err := os.Open(sourceFilePath)
-				if err != nil {
-					return fmt.Errorf("failed to open source file: %w", err)
-				}
-				defer sourceFile.Close()
-				sourceFileDir := filepath.Dir(sourceFilePath)
-				includeRegex := regexp.MustCompile(`^#include\s+"([^"]+)"$`)
-				scanner := bufio.NewScanner(sourceFile)
-				for scanner.Scan() {
-					if matches := includeRegex.FindStringSubmatch(scanner.Text()); matches != nil {
-						matchedFilePath := matches[1]
-						if matchedFilePath != "testlib.h" {
-							includedFilePath := filepath.Join(sourceFileDir, matchedFilePath)
-							if err := parseAndWriteSourceFile(includedFilePath); err != nil {
-								return fmt.Errorf("failed to write included file %s: %w", matchedFilePath, err)
-							}
-						} else {
-							if _, err := writer.WriteString(scanner.Text()); err != nil {
-								return fmt.Errorf("failed to write to output file: %w", err)
-							}
-							if _, err := writer.WriteRune('\n'); err != nil {
-								return fmt.Errorf("failed to write to output file: %w", err)
-							}
-							outputDir := filepath.Dir(settings.OutputPath)
-							testlibOutputPath := filepath.Join(outputDir, "testlib.h")
-							if _, err := os.Stat(testlibOutputPath); os.IsNotExist(err) {
-								testlibRelPath, err := filepath.Rel(outputDir, filepath.Join(sourceFileDir, "testlib.h"))
-								if err != nil {
-									return fmt.Errorf("failed to get relative path for testlib: %w", err)
-								}
-								if err := os.Symlink(testlibRelPath, testlibOutputPath); err != nil {
-									return fmt.Errorf("failed to create symlink for testlib: %w", err)
-								}
-							}
+
+	spinner = out.WithSpinner("Pack source files")
+	if err := spinner.Start(); err != nil {
+		return err
+	}
+
+	outputFile, err := os.Create(settings.OutputPath)
+	if err != nil {
+		spinner.StopFail()
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer outputFile.Close()
+
+	writer := bufio.NewWriter(outputFile)
+	defer writer.Flush()
+
+	writeCount := make(map[string]int)
+	for _, sourceFilePath := range settings.SourceFiles {
+		var parseAndWriteSourceFile func(sourceFilePath string) error
+		parseAndWriteSourceFile = func(sourceFilePath string) error {
+			if _, ok := writeCount[sourceFilePath]; ok {
+				return nil
+			}
+			writeCount[sourceFilePath] = 1
+
+			sourceFile, err := os.Open(sourceFilePath)
+			if err != nil {
+				return fmt.Errorf("failed to open source file: %w", err)
+			}
+			defer sourceFile.Close()
+
+			sourceFileDir := filepath.Dir(sourceFilePath)
+			includeRegex := regexp.MustCompile(`^#include\s+"([^"]+)"$`)
+			scanner := bufio.NewScanner(sourceFile)
+
+			for scanner.Scan() {
+				if matches := includeRegex.FindStringSubmatch(scanner.Text()); matches != nil {
+					matchedFilePath := matches[1]
+					if matchedFilePath != "testlib.h" {
+						includedFilePath := filepath.Join(sourceFileDir, matchedFilePath)
+						if err := parseAndWriteSourceFile(includedFilePath); err != nil {
+							return fmt.Errorf("failed to write included file %s: %w", matchedFilePath, err)
 						}
 					} else {
 						if _, err := writer.WriteString(scanner.Text()); err != nil {
@@ -99,19 +94,43 @@ func Pack(settings PackSettings) error {
 						if _, err := writer.WriteRune('\n'); err != nil {
 							return fmt.Errorf("failed to write to output file: %w", err)
 						}
+
+						outputDir := filepath.Dir(settings.OutputPath)
+						testlibOutputPath := filepath.Join(outputDir, "testlib.h")
+						if _, err := os.Stat(testlibOutputPath); os.IsNotExist(err) {
+							testlibRelPath, err := filepath.Rel(outputDir, filepath.Join(sourceFileDir, "testlib.h"))
+							if err != nil {
+								return fmt.Errorf("failed to get relative path for testlib: %w", err)
+							}
+							if err := os.Symlink(testlibRelPath, testlibOutputPath); err != nil {
+								return fmt.Errorf("failed to create symlink for testlib: %w", err)
+							}
+						}
+					}
+				} else {
+					if _, err := writer.WriteString(scanner.Text()); err != nil {
+						return fmt.Errorf("failed to write to output file: %w", err)
+					}
+					if _, err := writer.WriteRune('\n'); err != nil {
+						return fmt.Errorf("failed to write to output file: %w", err)
 					}
 				}
-				return nil
 			}
-			if err := parseAndWriteSourceFile(sourceFilePath); err != nil {
-				return err
-			}
+			return nil
 		}
-		return nil
-	}); err != nil {
-		return err
+
+		if err := parseAndWriteSourceFile(sourceFilePath); err != nil {
+			spinner.StopFail()
+			return err
+		}
 	}
-	return nil
+
+	return spinner.Stop()
+}
+
+// Pack packs source files using the default terminal outputter (backward compatibility)
+func Pack(settings PackSettings) error {
+	return PackWithOutput(settings, output.DefaultTerminalOutputter())
 }
 
 func isUpToDate(outputPath string, sourceFiles []string) (bool, error) {

--- a/tools/ccli/submission/run.go
+++ b/tools/ccli/submission/run.go
@@ -2,12 +2,11 @@ package submission
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"os/exec"
 	"time"
 
-	"github.com/fatih/color"
+	"github.com/STommydx/cp-templates/tools/ccli/output"
 	"github.com/pkg/errors"
 )
 
@@ -16,32 +15,46 @@ type RunSettings struct {
 	Args           []string
 }
 
-func Run(settings RunSettings) error {
+// RunWithOutput runs an executable with the given outputter for messaging
+func RunWithOutput(settings RunSettings, out output.Outputter) error {
 	cmd := exec.Command(settings.ExecutablePath, settings.Args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
 	startTime := time.Now()
 	var execErr *exec.ExitError
 	err := cmd.Run()
+
 	if err != nil && !errors.As(err, &execErr) {
 		return err
 	}
+
 	elapsedTime := time.Since(startTime)
-	printColor := color.FgGreen
+
 	if cmd.ProcessState.ExitCode() != 0 {
-		printColor = color.FgRed
+		out.Errorf("Program exited with code %d", cmd.ProcessState.ExitCode())
+	} else {
+		out.Successf("Program exited with code %d", cmd.ProcessState.ExitCode())
 	}
-	color.New(printColor, color.Bold).Fprintf(os.Stderr, "Program exited with code %d\n", cmd.ProcessState.ExitCode())
-	fmt.Fprintf(os.Stderr, "Elapsed time: %s\n", elapsedTime)
+
+	out.Infof("Elapsed time: %s", elapsedTime)
+
 	extraTokens := 0
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Split(bufio.ScanWords)
 	for scanner.Scan() {
 		extraTokens++
 	}
+
 	if extraTokens > 0 {
-		color.New(color.FgYellow).Fprintf(os.Stderr, "⚠ %d extra tokens found\n", extraTokens)
+		out.Warnf("⚠ %d extra tokens found", extraTokens)
 	}
+
 	return nil
+}
+
+// Run runs an executable using the default terminal outputter (backward compatibility)
+func Run(settings RunSettings) error {
+	return RunWithOutput(settings, output.DefaultTerminalOutputter())
 }

--- a/tools/ccli/submission/submission_test.go
+++ b/tools/ccli/submission/submission_test.go
@@ -1,0 +1,137 @@
+package submission
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/STommydx/cp-templates/tools/ccli/output"
+)
+
+func TestCompileWithOutput(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "ccli_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a simple C++ file for testing
+	sourceFile := filepath.Join(tempDir, "test.cpp")
+	err = os.WriteFile(sourceFile, []byte("#include <iostream>\nint main() { std::cout << \"Hello, World!\" << std::endl; return 0; }"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test compiling the file
+	outputPath := filepath.Join(tempDir, "test.out")
+	settings := CompileSettings{
+		SourceFiles:      []string{sourceFile},
+		OutputPath:       outputPath,
+		CompilationFlags: []string{"-std=c++17"},
+	}
+
+	out := output.NewTestOutputter()
+	err = CompileWithOutput(settings, out)
+	if err != nil {
+		t.Errorf("CompileWithOutput failed: %v", err)
+	}
+
+	// Check that the output file was created
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		t.Error("Output file was not created")
+	}
+
+	// Check that the output contains expected messages
+	outputStr := out.Output()
+	if outputStr == "" {
+		t.Error("No output was generated")
+	}
+}
+
+func TestPackWithOutput(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "ccli_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a simple C++ file for testing
+	sourceFile := filepath.Join(tempDir, "test.cpp")
+	err = os.WriteFile(sourceFile, []byte("#include <iostream>\nint main() { std::cout << \"Hello, World!\" << std::endl; return 0; }"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test packing the file
+	outputPath := filepath.Join(tempDir, "test.pack.cpp")
+	settings := PackSettings{
+		SourceFiles: []string{sourceFile},
+		OutputPath:  outputPath,
+	}
+
+	out := output.NewTestOutputter()
+	err = PackWithOutput(settings, out)
+	if err != nil {
+		t.Errorf("PackWithOutput failed: %v", err)
+	}
+
+	// Check that the output file was created
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		t.Error("Output file was not created")
+	}
+
+	// Check that the output contains expected messages
+	outputStr := out.Output()
+	if outputStr == "" {
+		t.Error("No output was generated")
+	}
+}
+
+func TestRunWithOutput(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "ccli_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a simple C++ file for testing
+	sourceFile := filepath.Join(tempDir, "test.cpp")
+	err = os.WriteFile(sourceFile, []byte("#include <iostream>\nint main() { std::cout << \"Hello, World!\" << std::endl; return 0; }"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compile the file first
+	outputPath := filepath.Join(tempDir, "test.out")
+	compileSettings := CompileSettings{
+		SourceFiles:      []string{sourceFile},
+		OutputPath:       outputPath,
+		CompilationFlags: []string{"-std=c++17"},
+	}
+
+	compileOut := output.NewTestOutputter()
+	err = CompileWithOutput(compileSettings, compileOut)
+	if err != nil {
+		t.Errorf("CompileWithOutput failed: %v", err)
+	}
+
+	// Test running the compiled file
+	runSettings := RunSettings{
+		ExecutablePath: outputPath,
+	}
+
+	out := output.NewTestOutputter()
+	err = RunWithOutput(runSettings, out)
+	if err != nil {
+		t.Errorf("RunWithOutput failed: %v", err)
+	}
+
+	// Check that the output contains expected messages
+	outputStr := out.Output()
+	if outputStr == "" {
+		t.Error("No output was generated")
+	}
+}


### PR DESCRIPTION
- Created Outputter interface for abstracting output operations
- Implemented TerminalOutputter for terminal output and TestOutputter for testing
- Refactored submission package functions to accept Outputter interface
- Refactored repoinit package functions to accept Outputter interface
- Updated command implementations to use the new interface
- Added unit tests for all refactored components
- Maintained backward compatibility with existing API